### PR TITLE
AIPC-9: Return JWT token in register response

### DIFF
--- a/src/models/register.go
+++ b/src/models/register.go
@@ -24,5 +24,7 @@ func (rr *RegisterRequest) Validate() string {
 }
 
 type RegisterResponse struct {
-	Message string `json:"message"`
+	AccessToken string `json:"access_token"`
+	Success     bool   `json:"success"`
+	Message     string `json:"message"`
 }

--- a/src/server/handlers.go
+++ b/src/server/handlers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/AIPCB/auth-service/src/models"
@@ -29,6 +30,7 @@ func (s *Server) RegisterHandler() http.HandlerFunc {
 		token, err := s.GenerateToken()
 		if err != nil {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
+			log.Printf("Error generating token: %v", err)
 			return
 		}
 

--- a/src/server/handlers.go
+++ b/src/server/handlers.go
@@ -24,8 +24,18 @@ func (s *Server) RegisterHandler() http.HandlerFunc {
 			return
 		}
 
+		// todo: make call to user service to create user
+
+		token, err := s.GenerateToken()
+		if err != nil {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
 		response := models.RegisterResponse{
-			Message: fmt.Sprintf("Successfully registered user"),
+			Message:     fmt.Sprintf("Successfully registered user"),
+			Success:     true,
+			AccessToken: token,
 		}
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This pull request introduces changes to the user registration flow by adding an access token to the registration response and generating this token upon successful user registration. The most important changes include updates to the `RegisterResponse` struct and the `RegisterHandler` function.

Changes to registration response:

* [`src/models/register.go`](diffhunk://#diff-b5ab217acef76026cf0f913a4c31f9112397b153052917bb786db21bb9e98472R27-R28): Added `AccessToken` and `Success` fields to the `RegisterResponse` struct.

Changes to registration handler:

* [`src/server/handlers.go`](diffhunk://#diff-b108f499564dcf07c1ddff3ac4335f8263452b5601da8b09fc0e73cb9ff997e6R27-R38): Updated the `RegisterHandler` function to generate an access token and include it in the registration response.