### PR TITLE
AIPC-17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AIPCB/auth-service
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/exception-raised/validation-module v0.0.1
@@ -13,3 +13,5 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 )
+
+require github.com/AIPCB/shared v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/AIPCB/shared v0.0.1 h1:XT9FaAwxHqvvXNXOmihcO91O8UANDQ/4x29OrsrLXpk=
+github.com/AIPCB/shared v0.0.1/go.mod h1:KOjLWxajzXUiBEAurDUsiBlJywS0BKttEB6TDWMZ4Ss=
+github.com/AIPCB/shared v0.0.2 h1:0ipkvLjK2JApBKyp/zZEcbL6avzGcJ3+98s9KzDlFw0=
+github.com/AIPCB/shared v0.0.2/go.mod h1:KOjLWxajzXUiBEAurDUsiBlJywS0BKttEB6TDWMZ4Ss=
 github.com/exception-raised/validation-module v0.0.1 h1:KBf+85ISrWnnWIHhyqDSjdaRPzy5ICN+9lzMO/snFhE=
 github.com/exception-raised/validation-module v0.0.1/go.mod h1:i1qu2YAWuQopIgZIc8lX/kGoo5akPvjZa7LoEHF9bQM=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=

--- a/src/cmd/server/server.go
+++ b/src/cmd/server/server.go
@@ -48,6 +48,11 @@ func Execute() {
 		}),
 	)
 
+	if err != nil {
+		log.Fatalf("Failed to create person service: %+v", err)
+		return
+	}
+
 	s := server.NewServer(
 		server.WithAuthService(authService),
 		server.WithPersonService(personService),

--- a/src/cmd/server/server.go
+++ b/src/cmd/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"log"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,6 +12,7 @@ import (
 	"github.com/AIPCB/auth-service/src/cmd/config"
 	"github.com/AIPCB/auth-service/src/server"
 	"github.com/AIPCB/auth-service/src/service"
+	"github.com/AIPCB/auth-service/src/service/person"
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 )
@@ -39,8 +41,16 @@ func Execute() {
 		return
 	}
 
+	personService, err := person.NewPersonService(
+		person.WithPersonServiceURL(&url.URL{
+			Scheme: "http",
+			Host:   os.Getenv("PERSON_SERVICE_HOST"),
+		}),
+	)
+
 	s := server.NewServer(
 		server.WithAuthService(authService),
+		server.WithPersonService(personService),
 		server.WithJWTExpiryTime(time.Hour*24),
 		server.WithJWTSecret(os.Getenv("JWT_SECRET")),
 	)

--- a/src/models/register.go
+++ b/src/models/register.go
@@ -6,7 +6,7 @@ import (
 
 type RegisterRequest struct {
 	Email    string `json:"email"`
-	Username string `json:"username"`
+	Name     string `json:"name"`
 	Password string `json:"password"`
 }
 

--- a/src/models/register_test.go
+++ b/src/models/register_test.go
@@ -37,7 +37,7 @@ func TestRegisterValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := RegisterRequest{
 				Email:    tc.email,
-				Username: tc.username,
+				Name:     tc.username,
 				Password: tc.password,
 			}
 

--- a/src/server/handlers.go
+++ b/src/server/handlers.go
@@ -25,7 +25,12 @@ func (s *Server) RegisterHandler() http.HandlerFunc {
 			return
 		}
 
-		// todo: make call to user service to create user
+		err = s.personService.CreatePerson(r.Context(), req)
+		if err != nil {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			log.Printf("Error creating person: %v", err)
+			return
+		}
 
 		token, err := s.GenerateToken()
 		if err != nil {

--- a/src/server/options.go
+++ b/src/server/options.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/AIPCB/auth-service/src/service"
+	"github.com/AIPCB/auth-service/src/service/person"
 	"github.com/AIPCB/auth-service/src/storage"
 )
 
@@ -12,6 +13,12 @@ type Option func(*Server)
 func WithAuthService(authService *service.Service) Option {
 	return func(server *Server) {
 		server.authService = authService
+	}
+}
+
+func WithPersonService(personService *person.PersonService) Option {
+	return func(server *Server) {
+		server.personService = personService
 	}
 }
 

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AIPCB/auth-service/src/service"
+	"github.com/AIPCB/auth-service/src/service/person"
 	"github.com/AIPCB/auth-service/src/storage"
 	"github.com/gorilla/mux"
 )
@@ -16,8 +17,9 @@ type Server struct {
 	httpreadtimeout  time.Duration
 	httpwritetimeout time.Duration
 
-	authService *service.Service
-	storage     storage.Client
+	authService   *service.Service
+	personService *person.PersonService
+	storage       storage.Client
 
 	jwtSecret     []byte
 	jwtExpiryTime time.Duration

--- a/src/service/person/client.go
+++ b/src/service/person/client.go
@@ -3,7 +3,6 @@ package person
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 
 	"github.com/AIPCB/auth-service/src/models"
@@ -22,7 +21,7 @@ func NewPersonService(opts ...Option) (*PersonService, error) {
 	}
 
 	if s.url == nil {
-		return nil, errors.New("service: missing storage")
+		return nil, errors.New("service: missing PersonService URL")
 	}
 
 	s.client = httpclient.New(s.url.String())
@@ -37,7 +36,5 @@ func (s *PersonService) CreatePerson(ctx context.Context, req models.RegisterReq
 		return err
 	}
 
-	fmt.Println(resp)
 	return nil
-
 }

--- a/src/service/person/client.go
+++ b/src/service/person/client.go
@@ -1,0 +1,43 @@
+package person
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/AIPCB/auth-service/src/models"
+	httpclient "github.com/AIPCB/shared/src/http"
+)
+
+type PersonService struct {
+	url    *url.URL
+	client *httpclient.Client
+}
+
+func NewPersonService(opts ...Option) (*PersonService, error) {
+	s := &PersonService{}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	if s.url == nil {
+		return nil, errors.New("service: missing storage")
+	}
+
+	s.client = httpclient.New(s.url.String())
+
+	return s, nil
+}
+
+func (s *PersonService) CreatePerson(ctx context.Context, req models.RegisterRequest) error {
+	resp := &models.RegisterResponse{}
+	err := s.client.DoRequest(ctx, "POST", "create-person", req, resp)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(resp)
+	return nil
+
+}

--- a/src/service/person/options.go
+++ b/src/service/person/options.go
@@ -1,0 +1,13 @@
+package person
+
+import (
+	"net/url"
+)
+
+type Option func(*PersonService)
+
+func WithPersonServiceURL(url *url.URL) Option {
+	return func(s *PersonService) {
+		s.url = url
+	}
+}


### PR DESCRIPTION
This pull request introduces a new integration with the `PersonService` to handle user-related operations, updates the `RegisterRequest` model to replace `Username` with `Name`, and makes several supporting changes to the codebase. The most important changes are grouped below by theme.

### Integration with `PersonService`:

* Added a new `PersonService` client in `src/service/person/client.go` to handle creating persons via an HTTP client. This includes a `CreatePerson` method and configuration options in `src/service/person/options.go`. [[1]](diffhunk://#diff-0160e74cd5a37147f8f59bfd8b22dd808534b5586caf33be8ead4bafdaee4b3bR1-R43) [[2]](diffhunk://#diff-687256c240bdac60a0863b352512873403165191f067feb55ab3f2982dcf2569R1-R13)
* Updated `src/cmd/server/server.go` to initialize the `PersonService` with a URL derived from environment variables and pass it to the server.
* Added a `WithPersonService` option in `src/server/options.go` to inject the `PersonService` into the server.
* Extended the `Server` struct in `src/server/server.go` to include a `personService` field.
* Updated the `RegisterHandler` in `src/server/handlers.go` to call `PersonService.CreatePerson` and handle errors.

### Model updates:

* Replaced the `Username` field with `Name` in the `RegisterRequest` model in `src/models/register.go` to align with the new `PersonService` requirements.
* Updated the corresponding test in `src/models/register_test.go` to reflect the change from `Username` to `Name`.

### Dependency and configuration updates:

* Updated the Go version in `go.mod` from `1.24.0` to `1.24.2` and added a dependency on `github.com/AIPCB/shared v0.0.2`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R16-R17)
* Added imports for the new `PersonService` package in various files, including `src/cmd/server/server.go`, `src/server/options.go`, and `src/server/server.go`. [[1]](diffhunk://#diff-cbd84ef1e9a210e385de6c3f92706cf1a2cd40cccc1a3dc0085f3040b83b2327R15) [[2]](diffhunk://#diff-03086e56322186dee66d7ce321498cf101310ac491dc345b494321adf8c8a7f8R7) [[3]](diffhunk://#diff-7c231c77af729592491bc0f9b17aa276485d4fe67cadaf09d4b7ee961b945947R9)